### PR TITLE
Add TaggableCacheItemPoolInterface to CachePoolChain

### DIFF
--- a/src/Adapter/Chain/CachePoolChain.php
+++ b/src/Adapter/Chain/CachePoolChain.php
@@ -14,6 +14,7 @@ namespace Cache\Adapter\Chain;
 use Cache\Adapter\Chain\Exception\NoPoolAvailableException;
 use Cache\Adapter\Chain\Exception\PoolFailedException;
 use Cache\Adapter\Common\Exception\CachePoolException;
+use Cache\TagInterop\TaggableCacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -22,7 +23,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
+class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface, TaggableCacheItemPoolInterface
 {
     /**
      * @type LoggerInterface


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description
CachePoolChain already has the required methods `invalidateTag` and `invalidateTags` but did not implement the `TaggableCacheItemPoolInterface`.

### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
